### PR TITLE
feat: use personal stats instance with near real-time sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 > "When in doubt, use brute force." — [Ken Thompson](https://en.wikipedia.org/wiki/Ken_Thompson)
 
 <a href="https://github.com/g8rdier">
-  <img align="center" height="170px" src="https://github-readme-stats.vercel.app/api?username=g8rdier&show_icons=true&theme=dark&cache_seconds=21600" />
+  <img align="center" height="170px" src="https://g8rdiers-github-readme-stats.vercel.app/api?username=g8rdier&show_icons=true&theme=dark&cache_seconds=1" />
 </a>
 <a href="https://github.com/g8rdier">
-  <img align="center" height="170px" src="https://github-readme-stats.vercel.app/api/top-langs/?username=g8rdier&layout=compact&show_icons=true&theme=dark&cache_seconds=21600" />
+  <img align="center" height="170px" src="https://g8rdiers-github-readme-stats.vercel.app/api/top-langs/?username=g8rdier&layout=compact&show_icons=true&theme=dark&cache_seconds=1" />
 </a>
 
 <picture>


### PR DESCRIPTION
## Summary
Updates GitHub stats cards to use personal Vercel instance with near real-time syncing.

## Changes
- Switch from public  to personal instance 
- Set  for near real-time updates (previously 6 hours)
- Personal instance configured to include:
  - Private repositories and contributions
  - Repos where I'm OWNER, COLLABORATOR, or ORGANIZATION_MEMBER
  - All lifetime commits

## Benefits
- Stats update almost instantly (1 second cache vs 6 hour cache)
- Includes private contributions
- Includes PRs and commits in organization repos
- More accurate representation of total activity